### PR TITLE
Lana/attractor

### DIFF
--- a/src/spaced/spaced/game/attractor.cpp
+++ b/src/spaced/spaced/game/attractor.cpp
@@ -1,0 +1,38 @@
+#include <glm/gtx/norm.hpp>
+#include <spaced/game/Attractor.hpp>
+
+namespace spaced {
+void Attractor::tick(bave::Seconds dt) {
+	dt += m_residue;
+	if (dt > max_dt) { return; }
+	for (; dt > 0s; dt -= time_slice) { integrate(); }
+	m_residue = dt;
+}
+
+void Attractor::integrate() {
+	auto const to_target = target - position;
+
+	if (glm::length2(to_target) < min_distance * min_distance) {
+		position = target;
+		return;
+	}
+
+	auto const gx = position.x;
+	auto const gy = position.y;
+	auto const mx = target.x;
+	auto const my = target.y;
+
+	auto force_x = mx - gx;
+	auto force_y = my - gy;
+	auto const mag = sqrt((force_x * force_x) + (force_y * force_y));
+	auto strength = force / mag * mag;
+	force_x *= strength;
+	force_y *= strength;
+	auto const acceleration = glm::vec2{force_x, force_y};
+
+	auto const dv = acceleration * time_slice.count();
+	m_velocity += dv;
+	m_velocity *= (1.0f - dampen);
+	position += m_velocity * time_slice.count();
+}
+} // namespace spaced

--- a/src/spaced/spaced/game/attractor.cpp
+++ b/src/spaced/spaced/game/attractor.cpp
@@ -2,6 +2,15 @@
 #include <spaced/game/Attractor.hpp>
 
 namespace spaced {
+
+using bave::RoundedQuad;
+
+Attractor::Attractor(Services const& services) {
+	auto rounded_quad = RoundedQuad{};
+	rounded_quad.size = glm::vec2{20.0f};
+	rounded_quad.corner_radius = 5.0f;
+	shape.set_shape(rounded_quad);
+}
 void Attractor::tick(bave::Seconds dt) {
 	dt += m_residue;
 	if (dt > max_dt) { return; }
@@ -10,12 +19,6 @@ void Attractor::tick(bave::Seconds dt) {
 }
 
 void Attractor::integrate() {
-	auto const to_target = target - position;
-
-	if (glm::length2(to_target) < min_distance * min_distance) {
-		position = target;
-		return;
-	}
 
 	auto const gx = position.x;
 	auto const gy = position.y;
@@ -34,5 +37,6 @@ void Attractor::integrate() {
 	m_velocity += dv;
 	m_velocity *= (1.0f - dampen);
 	position += m_velocity * time_slice.count();
+	shape.transform.position = position;
 }
 } // namespace spaced

--- a/src/spaced/spaced/game/attractor.hpp
+++ b/src/spaced/spaced/game/attractor.hpp
@@ -1,20 +1,26 @@
 #pragma once
 #include <bave/core/time.hpp>
 #include <glm/vec2.hpp>
+#include <bave/graphics/shape.hpp>
+#include <spaced/game/weapon.hpp>
 
 namespace spaced {
 class Attractor {
   public:
+	Attractor() = default;
+	Attractor(Services const& services);
+
 	glm::vec2 target{};
 	glm::vec2 position{};
 
 	bave::Seconds time_slice{1.0f / 250.0f};
 	bave::Seconds max_dt{0.8s};
-	float dampen{0.9f};
-	float force{0.01f};
+	float dampen{0.01f};
+	float force{4.1f};
 	float min_distance{0.1f};
 
 	void tick(bave::Seconds dt);
+	bave::RoundedQuadShape shape{};
 
   private:
 	void integrate();

--- a/src/spaced/spaced/game/attractor.hpp
+++ b/src/spaced/spaced/game/attractor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <bave/core/time.hpp>
+#include <glm/vec2.hpp>
+
+namespace spaced {
+class Attractor {
+  public:
+	glm::vec2 target{};
+	glm::vec2 position{};
+
+	bave::Seconds time_slice{1.0f / 250.0f};
+	bave::Seconds max_dt{0.8s};
+	float dampen{0.9f};
+	float force{0.01f};
+	float min_distance{0.1f};
+
+	void tick(bave::Seconds dt);
+
+  private:
+	void integrate();
+
+	glm::vec2 m_velocity{};
+	bave::Seconds m_residue{};
+};
+} // namespace spaced

--- a/src/spaced/spaced/game/player.cpp
+++ b/src/spaced/spaced/game/player.cpp
@@ -23,6 +23,7 @@ Player::Player(Services const& services, std::unique_ptr<IController> controller
 	rounded_quad.size = glm::vec2{100.0f};
 	rounded_quad.corner_radius = 20.0f;
 	ship.set_shape(rounded_quad);
+	m_highlight = Attractor(services);
 
 	debug_switch_weapon();
 }
@@ -36,6 +37,9 @@ void Player::on_tap(PointerTap const& pointer_tap) { m_controller->on_tap(pointe
 void Player::tick(std::span<NotNull<IDamageable*> const> targets, Seconds const dt) {
 	auto const y_position = m_controller->tick(dt);
 	set_y(y_position);
+
+	m_highlight.target = ship.transform.position;
+	m_highlight.tick(dt);
 
 	auto const muzzle_position = ship.transform.position + 0.5f * glm::vec2{ship.get_shape().size.x, 0.0f};
 	if (m_controller->is_firing() && m_debug.shots_remaining > 0) {
@@ -56,7 +60,7 @@ void Player::tick(std::span<NotNull<IDamageable*> const> targets, Seconds const 
 
 void Player::draw(Shader& shader) const {
 	ship.draw(shader);
-
+	m_highlight.shape.draw(shader);
 	for (auto const& round : m_weapon_rounds) { round->draw(shader); }
 }
 

--- a/src/spaced/spaced/game/player.hpp
+++ b/src/spaced/spaced/game/player.hpp
@@ -4,6 +4,7 @@
 #include <spaced/game/controller.hpp>
 #include <spaced/game/health.hpp>
 #include <spaced/game/weapon.hpp>
+#include <spaced/game/attractor.hpp>
 
 namespace spaced {
 class Player : public bave::IDrawable {
@@ -39,6 +40,7 @@ class Player : public bave::IDrawable {
 	std::unique_ptr<IController> m_controller;
 	std::unique_ptr<Weapon> m_weapon{};
 	std::vector<std::unique_ptr<Weapon::Round>> m_weapon_rounds{};
+	Attractor m_highlight{};
 
 	struct {
 		int shots_remaining{};


### PR DESCRIPTION
Prototype for `attractor`. Intended to be used for player-tracking projectiles, small magnet effect  for powerups, as well as certain visuals, like fluid highlights.

I believe the constituent members should be abstracted into a more general `physics` object, because this is quite similar to `spring-arm`.